### PR TITLE
Trigger build and artefacts when pushing to `release` branch

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,9 +3,7 @@ name: CMake
 on:
   push:
     branches:
-      - 'master'
-  pull_request:
-    branches: [ master ]
+      - 'release'
 
 env:
   BUILD_TYPE: RelWithDebInfo


### PR DESCRIPTION
I propose to only trigger building when we push to either the `release` branch.

That way we save resources and only these builds are suitable for testing and referenced to in the issue tracker.